### PR TITLE
HM14:Operators and CRD

### DIFF
--- a/kubernetes-operators/README.md
+++ b/kubernetes-operators/README.md
@@ -1,0 +1,70 @@
+### HomeWork Операторы,CustomResourceDefinition
+
+1. Запустить minikube (minikube start)
+2. Создал ветку kubernetes-operators и одноименную папку в корне проекта в созданной ветке
+3. Создал папку kubernetes-operators/deploy
+4. Создал манифест cr.yaml
+5. Попытался применить манифест, получил ожидаемую ошибку ```error: unable to recognize "deploy/cr.yml": no matches for kind "MySQL" in version "otus.homework/v1"```
+6. Создал манифест для описание ресурса deploy/crd.yaml
+7. Применил оба манифеста, описание ресураса и сам ресурс создались. ```customresourcedefinition.apiextensions.k8s.io/mysqls.otus.homework created
+mysql.otus.homework/mysql-instance created```
+8. Проверил наличие данных о созданных сущностях 
+    ```bash
+       $ kubectl get crd
+       NAME                   CREATED AT
+       mysqls.otus.homework   2021-07-19T19:58:42Z
+       $ kubectl get mysqls.otus.homework
+       NAME             AGE
+       mysql-instance   2m7s
+       $ kubectl describe mysqls.otus.homework mysql-instance
+       Name:         mysql-instance
+       Namespace:    default
+       ...
+    ```
+9.   Удалили созданный CR ```kubectl delete mysqls.otus.homework mysql-instance```
+10.  В манифест deploy/crd.yaml добавил секцию validation
+11.  Применил манифесты ``` customresourcedefinition.apiextensions.k8s.io/mysqls.otus.homework configured``` ```mysql.otus.homework/mysql-instance created```
+12.  Добавил в манифестк deploy.yaml секции required
+13.  Создали манифесты для:
+- service-account.yml
+- role.yml
+- role-binding.yml
+- deploy-operator.yml   
+14. Применили манифесты 
+    ```bash
+       $ kubectl apply -f deploy/service-account.yml
+       serviceaccount/mysql-operator created
+       $ kubectl apply -f deploy/role.yml
+       clusterrole.rbac.authorization.k8s.io/mysql-operator created
+       $ kubectl apply -f deploy/role-binding.yml
+       clusterrolebinding.rbac.authorization.k8s.io/workshop-operator created
+       $ kubectl apply -f deploy/deploy-operator.yml
+       deployment.apps/mysql-operator created
+    ```   
+15. Применил манифест deploy/cr.yaml ```$ kubectl apply -f deploy/cr.yml```
+16. Проверяем радоту оператора
+    ```bash
+       kubectl get pvc
+    ```   
+        | NAME                      | STATUS | VOLUME  | CAPACITY | ACCESS MODES | STORAGECLASS |  AGE |
+        |---------------------------|--------|---------|----------|--------------|--------------|------|
+        | backup-mysql-instance-pvc | Bound  | pvc-... |   1Gi    |      RWO     | standard     | 112s |
+        | mysql-instance-pvc        | Bound  | pvc-... |   1Gi    |      RWO     | standard     | 114s |
+
+17. Заполнили поднятую БД
+18. Проверели, что данные внесены
+   ```bash
+      $ kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
+   ```
+   ```sql
+        +----+-------------+
+        | id | name        |
+        +----+-------------+
+        |  1 | some data   |
+        |  2 | some data-2 |
+        +----+-------------+
+```    
+19. Удалили cr
+20. Проверяем, что зм больше нет
+21. Создали заново cr
+22. Проверили, что данные в бд остались

--- a/kubernetes-operators/deploy/cr.yml
+++ b/kubernetes-operators/deploy/cr.yml
@@ -1,0 +1,10 @@
+apiVersion: otus.homework/v1
+kind: MySQL
+metadata:
+  name: mysql-instance
+spec:
+  image: mysql:5.7
+  database: otus-database
+  password: otuspassword  # Так делать не нужно, следует использовать secret
+  storage_size: 1Gi
+usless_data: "useless info"

--- a/kubernetes-operators/deploy/crd.yml
+++ b/kubernetes-operators/deploy/crd.yml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework # имя CRD должно иметь формат plural.group
+spec:
+  scope: Namespaced     # Данный CRD будер работать в рамках namespace
+  group: otus.homework  # Группа, отражается в поле apiVersion CR
+  versions:             # Список версий
+    - name: v1
+      served: true      # Будет ли обслуживаться API-сервером данная версия
+      storage: true     # Фиксирует  версию описания, которая будет сохраняться в etcd
+  names:                # различные форматы имени объекта CR
+    kind: MySQL         # kind CR
+    plural: mysqls      
+    singular: mysql
+    shortNames:
+      - ms
+  validation:
+    openAPIV3Schema:
+      type: object
+      properties:
+        apiVersion:
+          type: string # Тип данных поля ApiVersion
+        kind:
+          type: string # Тип данных поля kind
+        metadata:
+          type: object
+          properties:
+            name:
+              type: string
+        spec:
+          type: object
+          properties:
+            image:
+              type: string
+            database:
+              type: string
+            password:
+              type: string
+            storage_size:
+              type: string
+          required:
+          - image
+          - database
+          - password
+          - storage_size
+      required:
+      - apiVersion
+      - kind
+      - metadata
+      - spec

--- a/kubernetes-operators/deploy/deploy-operator.yml
+++ b/kubernetes-operators/deploy/deploy-operator.yml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mysql-operator
+  template:
+    metadata:
+      labels:
+        name: mysql-operator
+    spec:
+      serviceAccountName: mysql-operator
+      containers:
+        - name: operator
+          image: "zhenkins/mysql-operator:v0.1"
+          imagePullPolicy: "Always"

--- a/kubernetes-operators/deploy/role-binding.yml
+++ b/kubernetes-operators/deploy/role-binding.yml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: workshop-operator
+subjects:
+- kind: ServiceAccount
+  name: mysql-operator
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: mysql-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-operators/deploy/role.yml
+++ b/kubernetes-operators/deploy/role.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: mysql-operator
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/kubernetes-operators/deploy/service-account.yml
+++ b/kubernetes-operators/deploy/service-account.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql-operator


### PR DESCRIPTION
### HomeWork Операторы,CustomResourceDefinition

1. Запустить minikube (minikube start)
2. Создал ветку kubernetes-operators и одноименную папку в корне проекта в созданной ветке
3. Создал папку kubernetes-operators/deploy
4. Создал манифест cr.yaml
5. Попытался применить манифест, получил ожидаемую ошибку ```error: unable to recognize "deploy/cr.yml": no matches for kind "MySQL" in version "otus.homework/v1"```
6. Создал манифест для описание ресурса deploy/crd.yaml
7. Применил оба манифеста, описание ресураса и сам ресурс создались. ```customresourcedefinition.apiextensions.k8s.io/mysqls.otus.homework created
mysql.otus.homework/mysql-instance created```
8. Проверил наличие данных о созданных сущностях 
    ```bash
       $ kubectl get crd
       NAME                   CREATED AT
       mysqls.otus.homework   2021-07-19T19:58:42Z
       $ kubectl get mysqls.otus.homework
       NAME             AGE
       mysql-instance   2m7s
       $ kubectl describe mysqls.otus.homework mysql-instance
       Name:         mysql-instance
       Namespace:    default
       ...
    ```
9.   Удалили созданный CR ```kubectl delete mysqls.otus.homework mysql-instance```
10.  В манифест deploy/crd.yaml добавил секцию validation
11.  Применил манифесты ``` customresourcedefinition.apiextensions.k8s.io/mysqls.otus.homework configured``` ```mysql.otus.homework/mysql-instance created```
12.  Добавил в манифестк deploy.yaml секции required
13.  Создали манифесты для:
- service-account.yml
- role.yml
- role-binding.yml
- deploy-operator.yml   
14. Применили манифесты 
    ```bash
       $ kubectl apply -f deploy/service-account.yml
       serviceaccount/mysql-operator created
       $ kubectl apply -f deploy/role.yml
       clusterrole.rbac.authorization.k8s.io/mysql-operator created
       $ kubectl apply -f deploy/role-binding.yml
       clusterrolebinding.rbac.authorization.k8s.io/workshop-operator created
       $ kubectl apply -f deploy/deploy-operator.yml
       deployment.apps/mysql-operator created
    ```   
15. Применил манифест deploy/cr.yaml ```$ kubectl apply -f deploy/cr.yml```
16. Проверяем радоту оператора
    ```bash
       kubectl get pvc
    ```   
        | NAME                      | STATUS | VOLUME  | CAPACITY | ACCESS MODES | STORAGECLASS |  AGE |
        |---------------------------|--------|---------|----------|--------------|--------------|------|
        | backup-mysql-instance-pvc | Bound  | pvc-... |   1Gi    |      RWO     | standard     | 112s |
        | mysql-instance-pvc        | Bound  | pvc-... |   1Gi    |      RWO     | standard     | 114s |

17. Заполнили поднятую БД
18. Проверели, что данные внесены
   ```bash
      $ kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
   ```
   ```sql
        +----+-------------+
        | id | name        |
        +----+-------------+
        |  1 | some data   |
        |  2 | some data-2 |
        +----+-------------+
```    
19. Удалили cr
20. Проверяем, что зм больше нет
21. Создали заново cr
22. Проверили, что данные в бд остались
23. Статус джобов выполнен
   ```sql
   | NAME                       | COMPLETIONS | DURATION |  AGE   |
   |----------------------------|-------------|----------|--------|
   | backup-mysql-instance-job  |  1/1        |   2s     |  9m31s |
   | restore-mysql-instance-job |  1/1        |   25m    |   25m  |
   
